### PR TITLE
Minimal CMake project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vs/*
 build*
 Testing*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build*
+Testing*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.21)
+
+if(NOT DEFINED PROJECT_NAME)
+    set(STD_MATRIX_IS_PRIMARY_PROJECT ON)
+endif()
+
+project(wg21-linear-algebra-matrix VERSION 0.8.0)
+
+include(CTest)
+include(FetchContent)
+include(GNUInstallDirs)
+include(CMakeDependentOption)
+include(CMakePackageConfigHelpers)
+
+cmake_dependent_option(MATRIX_ENABLE_TESTS "Enable std::math:linear_algebra tests" ON "BUILD_TESTING" OFF)
+
+add_library(std-matrix INTERFACE)
+target_include_directories(std-matrix
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+set_target_properties(std-matrix
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+)
+
+target_compile_features(std-matrix
+    INTERFACE
+        cxx_std_23
+)
+
+set_target_properties(std-matrix
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+if (${MATRIX_ENABLE_TESTS})
+    add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,33 @@
+FetchContent_Declare(catch2 GIT_REPOSITORY https://github.com/catchorg/Catch2 GIT_TAG v3.5.3)
+FetchContent_MakeAvailable(catch2)
+
+add_executable(test-std-matrix)
+
+target_sources(test-std-matrix
+    PRIVATE
+        matrix.tests.cpp
+)
+
+target_link_libraries(test-std-matrix
+    PRIVATE
+        std-matrix
+        Catch2::Catch2WithMain
+)
+
+set_target_properties(test-std-matrix
+    PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+add_test(
+    NAME test-std-matrix
+    COMMAND test-std-matrix
+    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+
+enable_testing()
+
+include(Catch)
+catch_discover_tests(test-std-matrix)


### PR DESCRIPTION
This adds the minimal project structure building an empty test executable with a main header only library (currently empty)